### PR TITLE
d3d12: use correct __uuidof operator

### DIFF
--- a/src/dawn/native/d3d12/AdapterD3D12.cpp
+++ b/src/dawn/native/d3d12/AdapterD3D12.cpp
@@ -67,7 +67,7 @@ MaybeError Adapter::InitializeImpl() {
     // rendering.
     const PlatformFunctions* functions = GetBackend()->GetFunctions();
     if (FAILED(functions->d3d12CreateDevice(GetHardwareAdapter(), D3D_FEATURE_LEVEL_11_0,
-                                            _uuidof(ID3D12Device), &mD3d12Device))) {
+                                            __uuidof(ID3D12Device), &mD3d12Device))) {
         return DAWN_INTERNAL_ERROR("D3D12CreateDevice failed");
     }
 


### PR DESCRIPTION
This is a pending CL being sent upstream to dawn.googlesource.com.

Status:

* [x] CL sent: https://dawn-review.googlesource.com/c/dawn/+/87309
* [x] Merged into our main branch

Helps https://github.com/hexops/mach/issues/86

---

It appears to be a typo that `_uuidof` (single underscore) was being used here
instead of `__uuidof` which is documented as the official operator by Microsoft:

https://docs.microsoft.com/en-us/cpp/cpp/uuidof-operator?view=msvc-170

Likely `_uuidof` and `__uuidof` are the same under msvc compilers, but Zig/clang/MinGW
compilers only expose the standard one and so this change improves compatability with
those compilers.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>