### PR TITLE
d3d12: fix constexpr compatability with clang

### DIFF
--- a/src/dawn/native/d3d12/TextureD3D12.cpp
+++ b/src/dawn/native/d3d12/TextureD3D12.cpp
@@ -824,7 +824,7 @@ void Texture::TransitionSubresourceRange(std::vector<D3D12_RESOURCE_BARRIER>* ba
     // non-simultaneous-access texture: NON_PIXEL_SHADER_RESOURCE,
     // PIXEL_SHADER_RESOURCE, COPY_SRC, COPY_DEST.
     {
-        static constexpr D3D12_RESOURCE_STATES kD3D12PromotableReadOnlyStates =
+        const D3D12_RESOURCE_STATES kD3D12PromotableReadOnlyStates =
             D3D12_RESOURCE_STATE_COPY_SOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE |
             D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
 


### PR DESCRIPTION
This is a pending CL being sent upstream to dawn.googlesource.com.

Status:

* [x] CL sent: https://dawn-review.googlesource.com/c/dawn/+/87381
* [x] Merged into our main branch

Helps https://github.com/hexops/mach/issues/86

---

This `static constexpr` fails to compile with clang in `-std=c++17` mode due to:

```
error: constexpr variable 'kD3D12PromotableReadOnlyStates' must be initialized by a constant expression
```

I'm not extremely familiar with constexpr to know if there is another better
fix for this, or if this is just some difference between clang and msvc, but
having this just be `static` doesn't seem too harmful and gets zig/clang
compatability which I'd love.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>