### PR TITLE
Fix undefined behaviour in BindGroupTracker when passing no dynamic offsets

### DIFF
--- a/src/dawn/native/BindGroupTracker.h
+++ b/src/dawn/native/BindGroupTracker.h
@@ -133,7 +133,9 @@ namespace dawn::native {
         static void SetDynamicOffsets(uint32_t* data,
                                       uint32_t dynamicOffsetCount,
                                       uint32_t* dynamicOffsets) {
-            memcpy(data, dynamicOffsets, sizeof(uint32_t) * dynamicOffsetCount);
+            if (dynamicOffsetCount > 0) {
+                memcpy(data, dynamicOffsets, sizeof(uint32_t) * dynamicOffsetCount);
+            }
         }
     };
 


### PR DESCRIPTION
This is a pending CL being sent upstream to dawn.googlesource.com.

Status:

* [x] CL sent: https://dawn-review.googlesource.com/c/dawn/+/87380
* [x] Merged into our main branch

Helps https://github.com/hexops/mach/issues/221
Helps https://bugs.chromium.org/p/dawn/issues/detail?id=1371

(originally sent at https://github.com/hexops/dawn/pull/9 - this PR is open merely as a reminder for myself to send the CL upstream to dawn.googlesource.com)