### PR TITLE
dawn/native/vulkan: correct undefined behavior in RenderPassCacheQuery

### DIFF
--- a/src/dawn/native/vulkan/CommandBufferVk.cpp
+++ b/src/dawn/native/vulkan/CommandBufferVk.cpp
@@ -207,7 +207,7 @@ namespace dawn::native::vulkan {
             // Query a VkRenderPass from the cache
             VkRenderPass renderPassVK = VK_NULL_HANDLE;
             {
-                RenderPassCacheQuery query;
+                RenderPassCacheQuery query{};
 
                 for (ColorAttachmentIndex i :
                      IterateBitSet(renderPass->attachmentState->GetColorAttachmentsMask())) {

--- a/src/dawn/native/vulkan/RenderPassCache.h
+++ b/src/dawn/native/vulkan/RenderPassCache.h
@@ -63,7 +63,7 @@ namespace dawn::native::vulkan {
         wgpu::StoreOp depthStoreOp;
         wgpu::LoadOp stencilLoadOp;
         wgpu::StoreOp stencilStoreOp;
-        bool readOnlyDepthStencil;
+        bool readOnlyDepthStencil = false;
 
         uint32_t sampleCount;
     };

--- a/src/dawn/native/vulkan/RenderPipelineVk.cpp
+++ b/src/dawn/native/vulkan/RenderPipelineVk.cpp
@@ -520,7 +520,7 @@ namespace dawn::native::vulkan {
         // so set them both to false.
         VkRenderPass renderPass = VK_NULL_HANDLE;
         {
-            RenderPassCacheQuery query;
+            RenderPassCacheQuery query{};
 
             for (ColorAttachmentIndex i : IterateBitSet(GetColorAttachmentsMask())) {
                 query.SetColor(i, GetColorAttachmentFormat(i), wgpu::LoadOp::Load,


### PR DESCRIPTION
This is a pending CL being sent upstream to dawn.googlesource.com.

Status:

* [x] CL sent: https://dawn-review.googlesource.com/c/dawn/+/87670
* [x] Merged into our main branch

Helps https://github.com/hexops/mach/issues/239
Helps https://bugs.chromium.org/p/dawn/issues/detail?id=1371

---

We've seen undefined behavior caught by UBSan terminating
in `dawn/native/CacheKey.h` on Linux using the Vulkan
backend during a call to `wgpuDeviceCreateRenderPipeline`:
https://github.com/hexops/mach/issues/239

After investigation, in `dawn/native/vulkan/CacheKeyVk.cpp:236`
the value `t.readOnlyDepthStencil` is undefined:

```
.Record(t.hasDepthStencil, t.depthStencilFormat, t.depthLoadOp, t.depthStoreOp,
        t.stencilLoadOp, t.stencilStoreOp, t.readOnlyDepthStencil, t.sampleCount);
```

The UB is introduced at `src/dawn/native/vulkan/RenderPipelineVk.cpp:519`
because `query` is undefined memory:

```
RenderPassCacheQuery query; // undefined memory

for (ColorAttachmentIndex i : IterateBitSet(GetColorAttachmentsMask())) {
    query.SetColor(i, GetColorAttachmentFormat(i), wgpu::LoadOp::Load,
                    wgpu::StoreOp::Store, false);
}

if (HasDepthStencilAttachment()) {
    query.SetDepthStencil(GetDepthStencilFormat(), wgpu::LoadOp::Load,
                            wgpu::StoreOp::Store, wgpu::LoadOp::Load,
                            wgpu::StoreOp::Store, false);
}
// query.readOnlyDepthStencil is undefined here
// when !HasDepthStencilAttachment()
```

This CL addresses the issue by giving `readOnlyDepthStencil`
a default `false` value and using struct initialization
syntax. An alternative would be to add an `else` statement
which explicitly sets the value to `false`.

Fixes hexops/mach#239
Bug: dawn:1371

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>