### PR TITLE
Dynamically load libX11 at runtime

### DIFF
--- a/src/dawn/native/BUILD.gn
+++ b/src/dawn/native/BUILD.gn
@@ -375,7 +375,6 @@ source_set("sources") {
   ]
 
   if (dawn_use_x11) {
-    libs += [ "X11" ]
     sources += [
       "XlibXcbFunctions.cpp",
       "XlibXcbFunctions.h",

--- a/src/dawn/native/Surface.cpp
+++ b/src/dawn/native/Surface.cpp
@@ -26,6 +26,7 @@
 
 #if defined(DAWN_USE_X11)
 #include "dawn/common/xlib_with_undefs.h"
+#include "dawn/native/XlibXcbFunctions.h"
 #endif  // defined(DAWN_USE_X11)
 
 namespace dawn::native {
@@ -64,7 +65,7 @@ absl::FormatConvertResult<absl::FormatConversionCharSet::kString> AbslFormatConv
 bool InheritsFromCAMetalLayer(void* obj);
 #endif  // defined(DAWN_ENABLE_BACKEND_METAL)
 
-MaybeError ValidateSurfaceDescriptor(const InstanceBase* instance,
+MaybeError ValidateSurfaceDescriptor(InstanceBase* instance,
                                      const SurfaceDescriptor* descriptor) {
     DAWN_INVALID_IF(descriptor->nextInChain == nullptr,
                     "Surface cannot be created with %s. nextInChain is not specified.", descriptor);
@@ -152,11 +153,12 @@ MaybeError ValidateSurfaceDescriptor(const InstanceBase* instance,
         // returns a status code. If the window is bad the call return a status of zero. We
         // need to set a temporary X11 error handler while doing this because the default
         // X11 error handler exits the program on any error.
-        XErrorHandler oldErrorHandler = XSetErrorHandler([](Display*, XErrorEvent*) { return 0; });
+        const XlibXcbFunctions* xlibXcb = instance->GetOrCreateXlibXcbFunctions();
+        XErrorHandler oldErrorHandler = xlibXcb->xSetErrorHandler([](Display*, XErrorEvent*) { return 0; });
         XWindowAttributes attributes;
-        int status = XGetWindowAttributes(reinterpret_cast<Display*>(xDesc->display), xDesc->window,
+        int status = xlibXcb->xGetWindowAttributes(reinterpret_cast<Display*>(xDesc->display), xDesc->window,
                                           &attributes);
-        XSetErrorHandler(oldErrorHandler);
+        xlibXcb->xSetErrorHandler(oldErrorHandler);
 
         DAWN_INVALID_IF(status == 0, "Invalid X Window");
         return {};

--- a/src/dawn/native/Surface.h
+++ b/src/dawn/native/Surface.h
@@ -34,7 +34,7 @@ struct IUnknown;
 
 namespace dawn::native {
 
-MaybeError ValidateSurfaceDescriptor(const InstanceBase* instance,
+MaybeError ValidateSurfaceDescriptor(InstanceBase* instance,
                                      const SurfaceDescriptor* descriptor);
 
 // A surface is a sum types of all the kind of windows Dawn supports. The OS-specific types

--- a/src/dawn/native/XlibXcbFunctions.cpp
+++ b/src/dawn/native/XlibXcbFunctions.cpp
@@ -17,7 +17,10 @@
 namespace dawn::native {
 
 XlibXcbFunctions::XlibXcbFunctions() {
-    if (!mLib.Open("libX11-xcb.so.1") || !mLib.GetProc(&xGetXCBConnection, "XGetXCBConnection")) {
+    if (!mLib.Open("libX11-xcb.so.1") ||
+        !mLib.GetProc(&xGetXCBConnection, "XGetXCBConnection") ||
+        !mLib.GetProc(&xSetErrorHandler, "XSetErrorHandler") ||
+        !mLib.GetProc(&xGetWindowAttributes, "XGetWindowAttributes")) {
         mLib.Close();
     }
 }

--- a/src/dawn/native/XlibXcbFunctions.h
+++ b/src/dawn/native/XlibXcbFunctions.h
@@ -36,6 +36,8 @@ class XlibXcbFunctions {
 
     // Functions from x11-xcb
     decltype(&::XGetXCBConnection) xGetXCBConnection = nullptr;
+    decltype(&::XSetErrorHandler) xSetErrorHandler = nullptr;
+    decltype(&::XGetWindowAttributes) xGetWindowAttributes = nullptr;
 
   private:
     DynamicLib mLib;


### PR DESCRIPTION
This is a pending CL being sent upstream to dawn.googlesource.com.

**Status:**

* [x] CL sent: https://dawn-review.googlesource.com/c/dawn/+/145400
* [x] Merged into our `main` branch

Originally https://github.com/hexops/dawn/pull/14

---

Prior to this change, Dawn would link directly against libX11.so which meant libX11.so must be installed on the system. However, not all Linux systems have X11 installed, some distros are Wayland-only, and runtime resolution is generally nicer.

This follows the existing XlibXcbFunctions implementation which was already largely doing this, and just ensures we do it for other X11 API usage as well.

Fixes https://bugs.chromium.org/p/dawn/issues/detail?id=1904
Fixes https://github.com/hexops/mach/issues/845

Change-Id: I6cd45970c6ad4c43fc9ae446a536afaad3e4894e